### PR TITLE
Fix txIdEncoders order in EVM predicates

### DIFF
--- a/.changeset/fifty-hornets-fix.md
+++ b/.changeset/fifty-hornets-fix.md
@@ -1,0 +1,5 @@
+---
+"@fuel-connectors/evm-predicates": minor
+---
+
+feat; rnadom

--- a/packages/evm-predicates/src/utils/txIdEncoders.ts
+++ b/packages/evm-predicates/src/utils/txIdEncoders.ts
@@ -23,11 +23,11 @@ const encodeTxIdLegacy = (txId: string): string => {
 };
 
 export const txIdEncoders: Record<EvmPredicateRoot, TxIdEncoder> = {
-  '0x3499b76bcb35d8bc68fb2fa74fbe1760461f64f0ac19890c0bacb69377ac19d2': {
-    encodeTxId: encodeTxIdUtf8,
-  },
   '0xbbae06500cd11e6c1d024ac587198cb30c504bf14ba16548f19e21fa9e8f5f95': {
     encodeTxId: encodeTxIdLegacy,
+  },
+  '0x3499b76bcb35d8bc68fb2fa74fbe1760461f64f0ac19890c0bacb69377ac19d2': {
+    encodeTxId: encodeTxIdUtf8,
   },
   '0xfdac03fc617c264fa6f325fd6f4d2a5470bf44cfbd33bc11efb3bf8b7ee2e938': {
     encodeTxId: encodeTxIdLegacy,


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->
random 

# Summary

This PR contains a minor code organization improvement:

**BurnerWalletConnector Variable Reordering:**
- Reordered class properties `external` and `installed` to maintain alphabetical order
- Changed the order from `installed = true; external = false;` to `external = false; installed = true;`
- Added changeset for minor version bump

This change is purely organizational and improves code readability by maintaining consistent alphabetical ordering of class properties. No functional behavior is affected.

# Breaking Changes

<!--
If the PR has breaking changes, please detail them in this section
and remove this comment.

Remove this section if there are no breaking changes.
-->

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)